### PR TITLE
Extract applied cards component

### DIFF
--- a/src/lib/checkout/checkout.js
+++ b/src/lib/checkout/checkout.js
@@ -5,6 +5,7 @@ import {
   CHECKOUT_STEP_SHIPPING_METHOD
 } from "../constants";
 import { CheckoutForm } from "./checkout_form";
+import { CheckoutAppliedCards } from "./checkout_applied_cards";
 
 const SUPPORTED_CHECKOUT_STEPS = [
   CHECKOUT_STEP_CONTACT_INFORMATION,
@@ -36,13 +37,20 @@ export class Checkout {
 
     // define an event handler for page changes
     const handlePageChange = () => {
-      document.querySelectorAll(SELECTOR_CHECKOUT_REDUCTION_FORM_WRAPPER).forEach(formWrapperElement => {
+      document.querySelectorAll(SELECTOR_CHECKOUT_REDUCTION_FORM_WRAPPER).forEach((formWrapperElement, index) => {
         // skip if the form wrapper is already initialised
         if(formWrapperElement.dataset.cardigan === 'true') {
           return;
         }
 
+        // initialise the checkout form component on this element
         new CheckoutForm(formWrapperElement, api, config, templates);
+
+        // if this is the first element on the page, also initialise the applied cards component
+        // this component should only exist once on the page
+        if(index === 0) {
+          new CheckoutAppliedCards(formWrapperElement, api, config);
+        }
       });
     };
 

--- a/src/lib/checkout/checkout_applied_cards.js
+++ b/src/lib/checkout/checkout_applied_cards.js
@@ -1,0 +1,123 @@
+import {
+  CHECKOUT_APPLIED_CARDS_CACHE_KEY,
+  SELECTOR_CHECKOUT_REDUCTION_CODE
+} from "../constants";
+
+export class CheckoutAppliedCards {
+
+  constructor(formWrapperElement, api, config) {
+    this.formWrapperElement = formWrapperElement;
+    this.api = api;
+    this.config = config;
+
+    this.initialise();
+  }
+
+  initialise() {
+    this.debug('initialise()');
+
+    const { formWrapperElement } = this;
+
+    // register event listeners
+    document.addEventListener('page:change', this.handlePageChange.bind(this));
+
+    // perform an initial check to remove applied cards if it's required
+    this.removeAppliedCardsIfRequired();
+
+    // mark this body element as initialised
+    formWrapperElement.dataset.cardigan = 'true';
+  }
+
+  handlePageChange() {
+    this.debug('handlePageChange()');
+
+    this.removeAppliedCardsIfRequired();
+  }
+
+  removeAppliedCardsIfRequired() {
+    this.debug('removeAppliedCardsIfRequired()');
+
+    const { api } = this;
+
+    const cachedAppliedCards = this.readAppliedCardCache();
+    const appliedCardTags = this.parseAppliedCardTags();
+
+    Object.keys(cachedAppliedCards).forEach(id => {
+      const cachedAppliedCard = cachedAppliedCards[id];
+
+      const isStillApplied = appliedCardTags.some(appliedCardTag => {
+        return appliedCardTag.lastCharacters === cachedAppliedCard.lastCharacters;
+      });
+
+      // if the card is still applied, nothing to do
+      if(isStillApplied) {
+        return;
+      }
+
+      api.removeCard({
+        id,
+        onSuccess: this.handleRemoveSuccess.bind(this)
+      });
+    });
+  }
+
+  parseAppliedCardTags() {
+    this.debug('parseAppliedCardTags()');
+
+    const { formWrapperElement } = this;
+    const giftCardRegex = new RegExp('•••• ([0-9]+)');
+
+    return Array.from(formWrapperElement.querySelectorAll(SELECTOR_CHECKOUT_REDUCTION_CODE)).map(reductionCodeElement => {
+      const matches = reductionCodeElement.innerText.match(giftCardRegex);
+
+      return {
+        lastCharacters: matches ? matches[1] : null
+      }
+    }).filter(appliedCardTag => {
+      return !!appliedCardTag.lastCharacters;
+    });
+  }
+
+  handleRemoveSuccess(result) {
+    this.debug('handleRemoveSuccess()', result);
+
+    this.clearAppliedCard(result.card.id);
+  }
+
+  readAppliedCardCache() {
+    this.debug('readAppliedCardCache()');
+
+    try {
+      return JSON.parse(localStorage.getItem(CHECKOUT_APPLIED_CARDS_CACHE_KEY)) || {};
+    } catch {
+      return {};
+    }
+  }
+
+  writeAppliedCardCache(appliedCards) {
+    this.debug('writeAppliedCardCache()', appliedCards);
+
+    try {
+      localStorage.setItem(CHECKOUT_APPLIED_CARDS_CACHE_KEY, JSON.stringify(appliedCards));
+    } catch {
+      return null;
+    }
+  }
+
+  clearAppliedCard(id) {
+    this.debug('clearAppliedCard()', id);
+
+    const appliedCards = this.readAppliedCardCache();
+    delete appliedCards[id];
+    this.writeAppliedCardCache(appliedCards);
+  }
+
+  debug(...args) {
+    if(!this.config.cardigan_js_debug) {
+      return;
+    }
+
+    console.log('[Cardigan Checkout Applied Cards]', ...args);
+  }
+
+}

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -15,6 +15,7 @@ export const SELECTOR_CHECKOUT_SUBMIT_BUTTON = '[type="submit"]';
 export const CHECKOUT_STEP_CONTACT_INFORMATION = 'contact_information';
 export const CHECKOUT_STEP_PAYMENT_METHOD = 'shipping_method';
 export const CHECKOUT_STEP_SHIPPING_METHOD = 'payment_method';
+export const CHECKOUT_APPLIED_CARDS_CACHE_KEY = 'cardigan:applied_cards';
 
 export const SELECTOR_PRODUCT_FORM_FORM = '[data-cardigan-product-form="form"]';
 export const SELECTOR_PRODUCT_FORM_RECIPIENT_NAME = '[data-cardigan-product-form="recipient-name"]';


### PR DESCRIPTION
Avoids an issue with double triggering the `remove` endpoint when multiple discount checkout forms exist on the legacy checkout page.