### PR TITLE
Don't rely on JS for product form identification

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -40,7 +40,6 @@ export const SELECTOR_PRODUCT_FORM_RECIPIENT_EMAIL = '[data-cardigan-product-for
 export const SELECTOR_PRODUCT_FORM_SENDER_NAME = '[data-cardigan-product-form="sender-name"]';
 export const SELECTOR_PRODUCT_FORM_GREETING = '[data-cardigan-product-form="greeting"]';
 export const SELECTOR_PRODUCT_FORM_DELIVERY_DATE = '[data-cardigan-product-form="delivery-date"]';
-export const SELECTOR_PRODUCT_FORM_PARENT_SECTION = '[data-section]';
 
 export const DEFAULT_TEMPLATE_BALANCE_CHECKER_RESULT_DEFAULT = '<span></span>';
 export const DEFAULT_TEMPLATE_BALANCE_CHECKER_RESULT_LOADING = '<span></span>';

--- a/src/lib/product_form/product_form_form.js
+++ b/src/lib/product_form/product_form_form.js
@@ -3,8 +3,7 @@ import {
   SELECTOR_PRODUCT_FORM_RECIPIENT_EMAIL,
   SELECTOR_PRODUCT_FORM_SENDER_NAME,
   SELECTOR_PRODUCT_FORM_GREETING,
-  SELECTOR_PRODUCT_FORM_DELIVERY_DATE,
-  SELECTOR_PRODUCT_FORM_PARENT_SECTION
+  SELECTOR_PRODUCT_FORM_DELIVERY_DATE
 } from "../constants";
 
 export class ProductFormForm {
@@ -29,31 +28,8 @@ export class ProductFormForm {
     this.greetingElement = formElement.querySelector(SELECTOR_PRODUCT_FORM_GREETING);
     this.deliveryDateElement = formElement.querySelector(SELECTOR_PRODUCT_FORM_DELIVERY_DATE);
 
-    // add `form` attributes to input elements from the parent section
-    // this ensures that on typical Shopify themes, line item properties are included in the add to cart request
-    this.addProductFormAttributesFromParentSection();
-
     // mark this form element as initialised
     formElement.dataset.cardigan = 'true';
-  }
-
-  addProductFormAttributesFromParentSection() {
-    this.debug('addProductFormAttributesFromParentSection()');
-
-    const parentSectionElement = this.formElement.closest(SELECTOR_PRODUCT_FORM_PARENT_SECTION);
-
-    if(!parentSectionElement) {
-      return;
-    }
-
-    const sectionId = parentSectionElement.getAttribute('data-section');
-    const productFormId = `product-form-${sectionId}`;
-
-    this.recipientNameElement && this.recipientNameElement.setAttribute('form', productFormId);
-    this.recipientEmailElement && this.recipientEmailElement.setAttribute('form', productFormId);
-    this.senderNameElement && this.senderNameElement.setAttribute('form', productFormId);
-    this.greetingElement && this.greetingElement.setAttribute('form', productFormId);
-    this.deliveryDateElement && this.deliveryDateElement.setAttribute('form', productFormId);
   }
 
   debug(...args) {


### PR DESCRIPTION
We now calculate and set the product form ID in Liquid in the theme app extension block, so this is no longer needed.