### PR TITLE
Support alternative API endpoints that don't pass information in URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,42 +211,6 @@ cardigan.api.getCardBalance({
 });
 ```
 
-### Get rewards balance
-Get the rewards balance for the given customer.
-
-This endpoint requires authentication via a customer session token; when calling it, the Cardigan.js library will automatically request a token for the logged in customer.
-Optionally, a token can be provided explicitly as part of the `options` argument (see [options](#options)).
-
-```js
-cardigan.api.getRewardsBalance({
-  id: '487348390022',
-  onSuccess: (result) => {
-    // this method will run if the API call succeeds, with `result` populated as:
-    // {
-    //   "rewards": {
-    //     "currency": "CAD",
-    //     "balance": "100.00",
-    //     "balance_formatted": "$100.00"
-    //   }
-    // }
-  },
-  onError: (result) => {
-    // this method will run if the API call fails, with `result` populated as:
-    // {
-    //   "errors": [
-    //     {
-    //       "code": "customer_not_found",
-    //       "description": "Could not find customer account."
-    //     }
-    //   ]
-    // }
-  },
-  onComplete: () => {
-    // this method will always run regardless of the result
-  }
-});
-```
-
 ### Apply gift card
 Validate the balance of a gift card and ensure a corresponding Shopify gift card is present, so that it can be applied to the Shopify checkout if required.
 
@@ -274,47 +238,6 @@ cardigan.api.applyCard({
     //     {
     //       "code": "invalid_pin",
     //       "description": "Provided PIN is invalid."
-    //     }
-    //   ]
-    // }
-  },
-  onComplete: () => {
-    // this method will always run regardless of the result
-  }
-});
-```
-
-### Apply rewards balance
-Validate the balance of a customer’s reward account and ensure a corresponding Shopify gift card is present, so that it can be applied to the Shopify checkout if required.
-
-It's rare that you will need to call this endpoint unless you're developing your own custom checkout integration with Cardigan.
-
-This endpoint requires authentication via a customer session token; when calling it, the Cardigan.js library will automatically request a token for the logged in customer.
-Optionally, a token can be provided explicitly as part of the `options` argument (see [options](#options)).
-
-```js
-cardigan.api.applyRewards({
-  id: '487348390022',
-  amount: '25.00',
-  onSuccess: (result) => {
-    // this method will run if the API call succeeds, with `result` populated as:
-    // {
-    //   "reward": {
-    //     "id": "018607f9-ce90-420f-cd2e-365a14515365",
-    //     "code": "2402476c03f20e56RWRD",
-    //     "currency": "CAD",
-    //     "balance": "100.00",
-    //     "amount": "75.00"
-    //   }
-    // }
-  },
-  onError: (result) => {
-    // this method will run if the API call fails, with `result` populated as:
-    // {
-    //   "errors": [
-    //     {
-    //       "code": "unauthorized",
-    //       "description": "Unauthorized."
     //     }
     //   ]
     // }

--- a/src/lib/api_client.js
+++ b/src/lib/api_client.js
@@ -6,12 +6,11 @@ const POST = 'post';
 const API_METHODS = {
   apply_card: {
     http_method: POST,
-    path: 'cards/:number/apply.json'
-  },
+    path: 'cards/apply.json'
   },
   get_card_balance: {
-    http_method: GET,
-    path: 'cards/:number.json'
+    http_method: POST,
+    path: 'cards/balance.json'
   },
   get_shop_config: {
     http_method: GET,
@@ -51,12 +50,25 @@ const getHttpMethod = (method) => {
 // Return whether the given method requires a token.
 const getRequiresToken = method => (API_METHODS[method].requires_token === true);
 
-// Return a combined set of query parameters for a request
-const getQueryParams = (params, currency, locale) => {
+// Get the request body for a request
+const getBody = (httpMethod, params) => {
+  if (httpMethod !== POST) {
+    return null;
+  }
+
+  return JSON.stringify(params);
+}
+
+// Return query parameters for a request - default parameters optionally merged with query parameters for a GET request
+const getQueryParams = (httpMethod, params, currency, locale) => {
   const defaultParams = {
     currency,
     locale
   };
+
+  if (httpMethod !== GET) {
+    return defaultParams;
+  }
 
   return Object.assign({}, defaultParams, params);
 };
@@ -92,7 +104,8 @@ export class ApiClient {
   async execute({ method, params, onSuccess, onError, onComplete, options = {} }) {
     const url = getUrl(this.endpoint, this.subdomain, method, params);
     const httpMethod = getHttpMethod(method);
-    const queryParams = getQueryParams(params, this.currency, this.locale);
+    const body = getBody(httpMethod, params);
+    const queryParams = getQueryParams(httpMethod, params, this.currency, this.locale);
     const requiresToken = getRequiresToken(method);
 
     // extract options
@@ -121,9 +134,10 @@ export class ApiClient {
     }
 
     const response = await fetch(url + buildQueryString(queryParams), {
+      body,
+      headers,
       method: httpMethod,
-      mode: 'cors',
-      headers: headers
+      mode: 'cors'
     });
 
     const json = await response.json();

--- a/src/lib/api_client.js
+++ b/src/lib/api_client.js
@@ -8,10 +8,6 @@ const API_METHODS = {
     http_method: POST,
     path: 'cards/:number/apply.json'
   },
-  apply_rewards: {
-    http_method: POST,
-    path: 'rewards/:id/apply.json',
-    requires_token: true
   },
   get_card_balance: {
     http_method: GET,
@@ -20,11 +16,6 @@ const API_METHODS = {
   get_shop_config: {
     http_method: GET,
     path: 'shop_config.json'
-  },
-  get_rewards_balance: {
-    http_method: GET,
-    path: 'rewards/:id.json',
-    requires_token: true
   },
   remove_card: {
     http_method: POST,
@@ -191,39 +182,12 @@ export class ApiClient {
     });
   }
 
-  getRewardsBalance({ id, onSuccess, onError, onComplete, options }) {
-    return this.execute({
-      method: 'get_rewards_balance',
-      params: {
-        id
-      },
-      onSuccess,
-      onError,
-      onComplete,
-      options
-    });
-  }
-
   applyCard({ number, pin, onSuccess, onError, onComplete, options }) {
     return this.execute({
       method: 'apply_card',
       params: {
         number,
         pin
-      },
-      onSuccess,
-      onError,
-      onComplete,
-      options
-    });
-  }
-
-  applyRewards({ id, amount, onSuccess, onError, onComplete, options }) {
-    return this.execute({
-      method: 'apply_rewards',
-      params: {
-        id,
-        amount
       },
       onSuccess,
       onError,


### PR DESCRIPTION
A merchant flagged [this OWASP](https://owasp.org/www-community/vulnerabilities/Information_exposure_through_query_strings_in_url) recommendation, which seems generally sensible. This PR provides alternative endpoints for our two endpoints that currently take card numbers and PINs in the URL (get balance and apply card) that only receive sensitive information in POST parameters.

This PR also drops the now-unused Rewards endpoints.